### PR TITLE
fix(overlay): keep feed overlay non-focusable to allow launcher keyboard input

### DIFF
--- a/app/src/main/java/com/saulhdev/feeder/manager/service/OverlayView.kt
+++ b/app/src/main/java/com/saulhdev/feeder/manager/service/OverlayView.kt
@@ -76,6 +76,11 @@ class OverlayView(val context: Context) :
 
         themeHolder = OverlayThemeHolder(this)
 
+        // Start fully transparent so the overlay never covers the launcher/folders
+        // while it is closed (for example, before the first onScroll callback arrives).
+        val bgColor = themeHolder.currentTheme.get(CardTheme.Colors.OVERLAY_BG.ordinal)
+        getWindow().setBackgroundDrawable(ColorDrawable((bgColor and 0x00ffffff)))
+
         initRecyclerView()
         initHeader()
         refreshNotifications()
@@ -329,8 +334,10 @@ class OverlayView(val context: Context) :
         super.onScroll(f)
 
         val bgColor = themeHolder.currentTheme.get(CardTheme.Colors.OVERLAY_BG.ordinal)
-        val color =
-            (prefs.overlayTransparency.getValue() * 255.0f).toInt() shl 24 or (bgColor and 0x00ffffff)
+        // When the panel is closed (progress 0) the overlay must be fully transparent
+        // so it does not cover the launcher/folders.
+        val alpha = if (f <= 0f) 0f else prefs.overlayTransparency.getValue()
+        val color = (alpha * 255.0f).toInt() shl 24 or (bgColor and 0x00ffffff)
         getWindow().setBackgroundDrawable(ColorDrawable(color))
     }
 

--- a/google-gsa/src/main/java/com/google/android/libraries/gsa/d/a/OverlayController.java
+++ b/google-gsa/src/main/java/com/google/android/libraries/gsa/d/a/OverlayController.java
@@ -147,9 +147,12 @@ public class OverlayController extends DialogOverlayController {
 
     public void setVisible(boolean visible) {
         if (visible) {
-            window.clearFlags(24); // FLAG_NOT_TOUCHABLE | FLAG_NOT_FOCUSABLE
+            // Make the overlay touchable so the feed can be interacted with,
+            // but keep it non-focusable so the launcher/IME target never moves
+            // away from the launcher window.
+            window.clearFlags(16); // FLAG_NOT_TOUCHABLE
         } else {
-            window.addFlags(24);
+            window.addFlags(16); // FLAG_NOT_TOUCHABLE
         }
     }
 

--- a/google-gsa/src/main/java/com/google/android/libraries/gsa/d/a/OverlayControllerCallback.java
+++ b/google-gsa/src/main/java/com/google/android/libraries/gsa/d/a/OverlayControllerCallback.java
@@ -163,11 +163,18 @@ abstract class OverlayControllerCallback extends BaseCallback {
 
         layoutParams.width = LayoutParams.MATCH_PARENT;
         layoutParams.height = LayoutParams.MATCH_PARENT;
-        layoutParams.flags |= 8650752;
+        // Start fully transparent, non-focusable and non-touchable so the overlay
+        // never briefly covers the launcher while it is being attached.
+        layoutParams.flags |= 8650752
+                | LayoutParams.FLAG_NOT_FOCUSABLE
+                | LayoutParams.FLAG_NOT_TOUCHABLE;
+        layoutParams.alpha = 0f;
         layoutParams.dimAmount = 0f;
         layoutParams.gravity = 3;
         layoutParams.type = 4;
-        layoutParams.softInputMode = LayoutParams.SOFT_INPUT_STATE_VISIBLE;
+        // Don't override the launcher window's soft-input behaviour; otherwise
+        // the app-drawer search box can't show its own keyboard.
+        layoutParams.softInputMode = LayoutParams.SOFT_INPUT_STATE_UNSPECIFIED;
 
         controller.window.setAttributes(layoutParams);
         controller.window.clearFlags(1048576);


### PR DESCRIPTION
When Neo-Feed is enabled as a launcher feed provider, the overlay window was temporarily made focusable while visible. This stole focus from the launcher, preventing the soft keyboard from appearing in the app drawer search field.

Keep FLAG_NOT_FOCUSABLE set at all times and only toggle FLAG_NOT_TOUCHABLE when showing/hiding the overlay. Also start the overlay with alpha 0 so it does not cover content before the first open gesture.

Fixes the long-standing issue where the keyboard does not show in the Neo-Launcher app drawer when Neo-Feed is enabled.